### PR TITLE
PR new version of hdx-redis-lib + limit number of iterations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests~=2.28.0
 gspread~=5.9.0
 python-json-logger~=2.0.7
-git+https://github.com/OCHA-DAP/hdx-redis-lib.git@0.2.3
+git+https://github.com/OCHA-DAP/hdx-redis-lib.git@0.3.0

--- a/run.py
+++ b/run.py
@@ -44,4 +44,4 @@ if __name__ == "__main__":
     event_bus = connect_to_hdx_event_bus_with_env_vars()
     logger.info('Connected to Redis')
 
-    event_bus.hdx_listen(event_processor, allowed_event_types=ALLOWED_EVENT_TYPES)
+    event_bus.hdx_listen(event_processor, allowed_event_types=ALLOWED_EVENT_TYPES, max_iterations=10_000)


### PR DESCRIPTION
-  New hdx-redis-lib version with support for storing/retrieving maps @danmihaila 
-  Added max number of iterations when listening for events from redis streams. That means that after 10 000 events the process will stop and docker will restart it. Helps avoid memory leaks
